### PR TITLE
10.2.2 Standalone Portal Fix

### DIFF
--- a/src/app/storymaps/tpl/core/MainView.js
+++ b/src/app/storymaps/tpl/core/MainView.js
@@ -174,6 +174,8 @@ define(["lib-build/css!./MainView",
 				//var popup = $("body").width() > 768 ? null : new PopupMobile(null, $("<div></div>")[0]);
 				var popup = null;
 				
+				arcgisUtils.arcgisUrl = arcgisUtils.arcgisUrl.replace('http:http','http');
+				
 				return arcgisUtils.createMap(webmapIdOrJSON, container, {
 					mapOptions: {
 						slider: true,


### PR DESCRIPTION
Fix for an issue that prevented the viewer panel to load any Web Map content when connected to a stand alone Portal instance instead of arcgis.com.
